### PR TITLE
Make Dockerfile work for using Docker CLI in workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,11 @@ RUN apt-get update && apt-get install -y ffmpeg
 # 7. (Optional) Install XVFB if there's a need to run browsers in headful mode
 RUN apt-get update && apt-get install -y xvfb
 
-COPY --chown=root:root . /app
+COPY package* /app/
+RUN npm ci --prefix /app
 
-RUN mkdir -p /app/artifacts
-RUN mkdir -p /app/artifacts/screenshots
+COPY . /app
 
-COPY scripts/test.sh /
-ENTRYPOINT ["/test.sh"]
+WORKDIR /app
+
+ENTRYPOINT ["/app/scripts/test.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,5 +63,4 @@ RUN mkdir -p /app/artifacts
 RUN mkdir -p /app/artifacts/screenshots
 
 COPY scripts/test.sh /
-USER root
 ENTRYPOINT ["/test.sh"]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-npm --prefix /app install
+set -ve
+
+mkdir -p /app/artifacts/screenshots
 node /app/node_modules/playwright/install.js
-chown -R $USER:$USER /github/home/.cache/ms-playwright/firefox-1122
-chown -R $USER:$USER /github/home/.cache/ms-playwright/firefox-1122/firefox/firefox
 DEBUG=pw:browser* npm --prefix /app test


### PR DESCRIPTION
This PR changes the Dockerfile to make it work with the Docker CLI in a workflow, rather than as an action.

- Move dependency installation to the Dockerfile
- Remove `chown`s which are no longer needed
- Remove `USER root` which is no longer needed
- Move creation of artifacts directory to `test.sh`—that way it's created inside a volume mounted in the container.